### PR TITLE
Add TTS support

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 toolchain go1.24.4
 
-require github.com/f18m/go-baresip v0.0.0-20250623221328-912091ab1b1a
+require github.com/f18m/go-baresip v0.0.0-20250625091842-8c55cce50885
 
 require (
 	github.com/goccy/go-json v0.10.5 // indirect

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,7 +4,7 @@ go 1.24
 
 toolchain go1.24.4
 
-require github.com/f18m/go-baresip v0.0.0-20250625091842-8c55cce50885
+require github.com/f18m/go-baresip v1.0.1
 
 require (
 	github.com/goccy/go-json v0.10.5 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,5 +1,7 @@
 github.com/f18m/go-baresip v0.0.0-20250625091842-8c55cce50885 h1:Xj/F/boD+F0/ur0TJqER6529RMaKZw+lst2ENc8kUIM=
 github.com/f18m/go-baresip v0.0.0-20250625091842-8c55cce50885/go.mod h1:flYhOS7i83wdM/eIWD2LbUIPqnGQGqBYEnoSjH1AYZw=
+github.com/f18m/go-baresip v1.0.1 h1:l4HhDyzzCjel/cMmLAPQDQXos8jWgsPowRAtSDZ9psU=
+github.com/f18m/go-baresip v1.0.1/go.mod h1:flYhOS7i83wdM/eIWD2LbUIPqnGQGqBYEnoSjH1AYZw=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/markdingo/netstring v1.0.2 h1:FptMPZdF/1QbW4gf8oVB7qE1GtZf7DgM7wq5o+dtS8o=

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,5 +1,5 @@
-github.com/f18m/go-baresip v0.0.0-20250623221328-912091ab1b1a h1:hSzRaWiX4xZGdK1t7kU/f5A1QX1ulLogUjn+z/KNJyQ=
-github.com/f18m/go-baresip v0.0.0-20250623221328-912091ab1b1a/go.mod h1:flYhOS7i83wdM/eIWD2LbUIPqnGQGqBYEnoSjH1AYZw=
+github.com/f18m/go-baresip v0.0.0-20250625091842-8c55cce50885 h1:Xj/F/boD+F0/ur0TJqER6529RMaKZw+lst2ENc8kUIM=
+github.com/f18m/go-baresip v0.0.0-20250625091842-8c55cce50885/go.mod h1:flYhOS7i83wdM/eIWD2LbUIPqnGQGqBYEnoSjH1AYZw=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/markdingo/netstring v1.0.2 h1:FptMPZdF/1QbW4gf8oVB7qE1GtZf7DgM7wq5o+dtS8o=

--- a/backend/main.go
+++ b/backend/main.go
@@ -69,7 +69,7 @@ func main() {
 	// using a simple Finite State Machine (FSM) -- all business logic is implemented in the FSM
 	cChan := gb.GetConnectedChan()
 	eChan := gb.GetEventChan()
-	rChan := gb.GetResponseChan()
+	//rChan := gb.GetResponseChan()
 	iChan := inputServer.GetInputChannel()
 	fsmInstance := fsm.NewVoipClientFSM(logger, gb, ttsService)
 
@@ -118,13 +118,14 @@ func main() {
 				default:
 					logger.InfoPkgf(logPrefix, "Ignoring event type %s", e.Type)
 				}
-
-			case r, ok := <-rChan:
-				if !ok {
-					continue
-				}
-				// logger.Info("RESPONSE: " + string(r.RawJSON))
-				_ = fsmInstance.OnBaresipCmdResponse(r)
+				/*
+					case r, ok := <-rChan:
+						if !ok {
+							continue
+						}
+						// logger.Info("RESPONSE: " + string(r.RawJSON))
+						_ = fsmInstance.OnBaresipCmdResponse(r)
+				*/
 			}
 		}
 	}()

--- a/backend/main.go
+++ b/backend/main.go
@@ -60,7 +60,7 @@ func main() {
 	}()
 
 	// Init the TTS service
-	ttsService := tts.NewTTSService(cfg.TTSEngine.Platform)
+	ttsService := tts.NewTTSService(logger, cfg.TTSEngine.Platform)
 
 	// Process
 	// - BARESIP events: unsolicited messages from baresip, e.g. incoming calls, registrations, etc.

--- a/backend/main.go
+++ b/backend/main.go
@@ -63,13 +63,12 @@ func main() {
 	ttsService := tts.NewTTSService(logger, cfg.TTSEngine.Platform)
 
 	// Process
+	// - BARESIP connected event: TCP socket connected
 	// - BARESIP events: unsolicited messages from baresip, e.g. incoming calls, registrations, etc.
-	// - BARESIP responses: responses to commands sent to baresip, e.g. command results
 	// - INPUT HTTP requests: messages coming from HomeAssistant via the HTTP server
 	// using a simple Finite State Machine (FSM) -- all business logic is implemented in the FSM
 	cChan := gb.GetConnectedChan()
 	eChan := gb.GetEventChan()
-	// rChan := gb.GetResponseChan()
 	iChan := inputServer.GetInputChannel()
 	fsmInstance := fsm.NewVoipClientFSM(logger, gb, ttsService)
 
@@ -118,14 +117,6 @@ func main() {
 				default:
 					logger.InfoPkgf(logPrefix, "Ignoring event type %s", e.Type)
 				}
-				/*
-					case r, ok := <-rChan:
-						if !ok {
-							continue
-						}
-						// logger.Info("RESPONSE: " + string(r.RawJSON))
-						_ = fsmInstance.OnBaresipCmdResponse(r)
-				*/
 			}
 		}
 	}()

--- a/backend/main.go
+++ b/backend/main.go
@@ -69,7 +69,7 @@ func main() {
 	// using a simple Finite State Machine (FSM) -- all business logic is implemented in the FSM
 	cChan := gb.GetConnectedChan()
 	eChan := gb.GetEventChan()
-	//rChan := gb.GetResponseChan()
+	// rChan := gb.GetResponseChan()
 	iChan := inputServer.GetInputChannel()
 	fsmInstance := fsm.NewVoipClientFSM(logger, gb, ttsService)
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -103,11 +103,17 @@ func main() {
 				case gobaresip.UA_EVENT_REGISTER_FAIL:
 					_ = fsmInstance.OnRegisterFail(e)
 
+				case gobaresip.UA_EVENT_CALL_OUTGOING:
+					_ = fsmInstance.OnCallOutgoing(e)
+
 				case gobaresip.UA_EVENT_CALL_ESTABLISHED:
 					_ = fsmInstance.OnCallEstablished(e)
 
 				case gobaresip.UA_EVENT_CALL_CLOSED:
 					_ = fsmInstance.OnCallClosed(e)
+
+				case gobaresip.UA_EVENT_END_OF_FILE:
+					_ = fsmInstance.OnEndOfFile(e)
 
 				default:
 					logger.InfoPkgf(logPrefix, "Ignoring event type %s", e.Type)

--- a/backend/main.go
+++ b/backend/main.go
@@ -13,6 +13,7 @@ import (
 	"voip-client-backend/pkg/fsm"
 	"voip-client-backend/pkg/httpserver"
 	"voip-client-backend/pkg/logger"
+	"voip-client-backend/pkg/tts"
 
 	"github.com/f18m/go-baresip/pkg/gobaresip"
 )
@@ -58,6 +59,9 @@ func main() {
 		inputServer.ListenAndServe()
 	}()
 
+	// Init the TTS service
+	ttsService := tts.NewTTSService(cfg.TTSEngine.Platform)
+
 	// Process
 	// - BARESIP events: unsolicited messages from baresip, e.g. incoming calls, registrations, etc.
 	// - BARESIP responses: responses to commands sent to baresip, e.g. command results
@@ -67,7 +71,7 @@ func main() {
 	eChan := gb.GetEventChan()
 	rChan := gb.GetResponseChan()
 	iChan := inputServer.GetInputChannel()
-	fsmInstance := fsm.NewVoipClientFSM(logger, gb)
+	fsmInstance := fsm.NewVoipClientFSM(logger, gb, ttsService)
 
 	// Initiate
 

--- a/backend/pkg/config/addon_options.go
+++ b/backend/pkg/config/addon_options.go
@@ -15,6 +15,10 @@ type AddonOptions struct {
 		Password string `json:"password"`
 	} `json:"voip_provider"`
 
+	TTSEngine struct {
+		Platform string `json:"platform"`
+	} `json:"tts_engine"`
+
 	Contacts []struct {
 		Name string `json:"name"`
 		URI  string `json:"uri"`

--- a/backend/pkg/fsm/fsm.go
+++ b/backend/pkg/fsm/fsm.go
@@ -149,7 +149,14 @@ func (fsm *VoipClientFSM) InitializeUserAgent(sip_uri, password string) error {
 func (fsm *VoipClientFSM) OnRegisterOk(event gobaresip.EventMsg) error {
 	fsm.logger.InfoPkgf(logPrefix, "Successful SIP REGISTER for: %s. This is good news. It means your 'voip_provider' addon configuration is valid and Baresip authenticated against your VOIP provider. Now calls can be made and can be received!", event.AccountAOR)
 	fsm.registered = true
-	fsm.transitionTo(WaitingInputs)
+
+	if fsm.currentState == WaitingUserAgentRegistration {
+		fsm.transitionTo(WaitingInputs)
+	}
+	//else: Baresip (as every SIP UA) will periodically re-attempt registration (typically every 1h);
+	//      when that happens this function gets invoked and it might even happen during an outgoing call;
+	//      in such (unlikely) case, remain in whatever state the FSM already is
+
 	return nil
 }
 

--- a/backend/pkg/tts/tts.go
+++ b/backend/pkg/tts/tts.go
@@ -1,0 +1,83 @@
+package tts
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+const ttsUrl = "http://hassio/homeassistant/api/tts_get_url"
+
+type TTSService struct {
+	platform string
+}
+
+type TTSRequestPayload struct {
+	Message  string `json:"message"`
+	Platform string `json:"platform"`
+}
+type TTSResponsePayload struct {
+	URL  string `json:"url"`
+	Path string `json:"path"`
+}
+
+func NewTTSService(platform string) *TTSService {
+	return &TTSService{
+		platform: platform,
+	}
+}
+
+func (t *TTSService) GetTTSURL(message string) (*TTSResponsePayload, error) {
+
+	hassioToken := os.Getenv("HASSIO_TOKEN")
+	if hassioToken == "" {
+		return nil, fmt.Errorf("HASSIO_TOKEN environment variable is not set")
+	}
+
+	payload := TTSRequestPayload{
+		Message:  message,
+		Platform: t.platform,
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling payload: %v", err)
+	}
+
+	req, err := http.NewRequest("POST", ttsUrl, bytes.NewReader(payloadBytes))
+	if err != nil {
+		return nil, fmt.Errorf("error creating request: %v", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+hassioToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error making request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response body: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error response from TTS service: %s", string(body))
+	}
+
+	var responsePayload TTSResponsePayload
+	err = json.Unmarshal(body, &responsePayload)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling response: %v", err)
+	}
+	if responsePayload.URL == "" {
+		return nil, fmt.Errorf("TTS service returned empty URL")
+	}
+
+	return &responsePayload, nil
+}

--- a/backend/pkg/tts/tts.go
+++ b/backend/pkg/tts/tts.go
@@ -23,9 +23,12 @@ type TTSService struct {
 }
 
 // see https://www.home-assistant.io/integrations/tts/#rest-api
+// and https://www.home-assistant.io/integrations/google_translate/
 type haTTSOptions struct {
-	PreferredFormat     string `json:"preferred_format"`
-	PreferredSampleRate string `json:"preferred_sample_rate"`
+	PreferredFormat         string `json:"preferred_format"`
+	PreferredSampleRate     string `json:"preferred_sample_rate"`
+	PreferredSampleChannels string `json:"preferred_sample_channels"`
+	PreferredSampleBytes    string `json:"preferred_sample_bytes"`
 }
 type haTTSRequestPayload struct {
 	Message  string       `json:"message"`
@@ -54,9 +57,16 @@ func (t *TTSService) getTTSURL(message string) (*haTTSResponsePayload, error) {
 	payload := haTTSRequestPayload{
 		Message:  message,
 		Platform: t.platform,
+
+		// The TTS options are dictated by Baresip which supports (via the "aufile" module)
+		// only the following specifications: monochannel, 8kHz, 16bit WAV
+		// If we had to do the conversion ourselves, using ffmpeg CLI utility it would be:
+		//  ffmpeg -i input.wav -ac 1 -ar 8000 -acodec pcm_s16le baresip-audio.wav
 		Options: haTTSOptions{
-			PreferredFormat:     "wav",
-			PreferredSampleRate: "8000",
+			PreferredFormat:         "wav",
+			PreferredSampleRate:     "8000",
+			PreferredSampleChannels: "1", // monochannel
+			PreferredSampleBytes:    "2", // 16bit audio sampling
 		},
 	}
 	payloadBytes, err := json.Marshal(payload)

--- a/config.yaml
+++ b/config.yaml
@@ -48,6 +48,8 @@ options:
     #username: "your-username"
     # the password to use for authentication with the VOIP provider
     password: "your-password"
+  tts_engine:
+    platform: google_translate
   contacts:
     - name: "John Doe"
       # the SIP URI of the contact, in the format
@@ -58,6 +60,8 @@ schema:
     name: str
     account: str
     password: str
+  tts_engine:
+    platform: str
   contacts:
     - name: str
       # the SIP URI of the contact, in the format

--- a/config.yaml
+++ b/config.yaml
@@ -26,6 +26,13 @@ image: ghcr.io/f18m/{arch}-addon-voip-client
 # init false because this addon uses s6-overlay
 init: false
 
+map:
+# map an host directory to the addon container, so that the addon can save permanently (as cache)
+# the audio files obtained from TTS
+  - type: share
+    read_only: false
+    path: /share/voip-client
+
 # no UI for now:
 # enable the ingress feature for this addon, see https://developers.home-assistant.io/docs/add-ons/presentation#ingress
 #ingress: true

--- a/config.yaml
+++ b/config.yaml
@@ -17,6 +17,10 @@ arch:
   - aarch64
   - amd64
   - i386
+
+# homeassistant_api is true to allow the addon to use the Home Assistant TTS API
+homeassistant_api: true
+
 host_network: false
 image: ghcr.io/f18m/{arch}-addon-voip-client
 # init false because this addon uses s6-overlay
@@ -60,5 +64,5 @@ schema:
       #  <sip:user@domain;uri-params>
       uri: str
 
-# categorize this addon as a "system" addon
-startup: system
+# categorize this addon as a "application" addon
+startup: application

--- a/config.yaml
+++ b/config.yaml
@@ -3,9 +3,9 @@
 # as reported by the Github Action workflow 'publish.yaml', so that you can force HomeAssistant
 # to use the docker image of that feature branch instead of the docker image of 'main', by pointing
 # HomeAssistant to that feature branch
-version: 0.2.0
-slug: voip-client
-name: VOIP Client
+version: beta
+slug: voip-client-beta
+name: VOIP Client BETA
 description: A Voice-Over-IP client based on Baresip. Make and receive phone calls from Home assistant!
 url: https://github.com/f18m/ha-addon-voip-client/tree/main
 # advanced true means that the HA user can see this addon only if it's flagged as 'advanced' in the


### PR DESCRIPTION
This PR is adding integration to the HomeAssistant TTS engine.
It simplifies the FSM by collapsing the status "send baresip cmd" + "wait for response" by using the new gobaresip.CmdTxWithAck() function.
It also moves to a stable go-baresip 1.0.1 version.