### PR TITLE
Add TTS cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,14 +145,13 @@ endif
 # E.g.
 #   make test-call TEST_CALL_PAYLOAD=./testing/test-httppayload-myphone.json
 #
+# NOTE that --raw is useful to see Trailers
+#
 test-call:
-	curl -vv http://localhost:$(TEST_CONTAINER_HOST_PORT)/dial \
+	curl -vv --raw \
+		http://localhost:$(TEST_CONTAINER_HOST_PORT)/dial \
 		-H "Content-Type: application/json" \
 		-d @$(TEST_CALL_PAYLOAD)
-
-
-
-
 
 
 # # NOTE: in the HTTP link below the port is actually the one in test-options.json, and currently it's 8976

--- a/backend/pkg/tts/tts.go
+++ b/backend/pkg/tts/tts.go
@@ -182,7 +182,7 @@ func (t *TTSService) GetAudioFile(message string) (string, error) {
 	}
 
 	// Prepare output directory
-	if err := os.MkdirAll(ttsDlPath, 0755); err != nil {
+	if err := os.MkdirAll(ttsDlPath, 0750); err != nil {
 		return "", fmt.Errorf("error creating directory %s: %w", ttsDlPath, err)
 	}
 

--- a/config.yaml
+++ b/config.yaml
@@ -31,7 +31,7 @@ map:
 # the audio files obtained from TTS
   - type: share
     read_only: false
-    path: /share/voip-client
+    path: /share
 
 # no UI for now:
 # enable the ingress feature for this addon, see https://developers.home-assistant.io/docs/add-ons/presentation#ingress

--- a/rootfs/etc/baresip/config
+++ b/rootfs/etc/baresip/config
@@ -8,23 +8,23 @@
 #------------------------------------------------------------------------------
 
 # SIP
-#sip_listen		0.0.0.0:5060
+#sip_listen		    0.0.0.0:5060
 #sip_certificate	cert.pem
-sip_cafile		/etc/pki/tls/certs/ca-bundle.crt
-sip_capath		/etc/pki/tls/certs
+sip_cafile		    /etc/pki/tls/certs/ca-bundle.crt
+sip_capath	    	/etc/pki/tls/certs
 #sip_transports		udp,tcp,tls,ws,wss
 #sip_trans_def		udp
 #sip_verify_server	yes
 #sip_verify_client	no
 #sip_tls_resumption	all
-sip_tos			160
+sip_tos			    160
 #filter_registrar	udp,tcp,tls,ws,wss
 
 # Call
-call_local_timeout	120
-call_max_calls		4
+call_local_timeout	    120
+call_max_calls		    4
 call_hold_other_calls	yes
-call_accept		no
+call_accept		        no
 
 # Audio
 audio_path		    /usr/share/baresip
@@ -36,7 +36,7 @@ audio_alert		    none
 #ausrc_channels		0
 #auplay_channels	0
 #audio_txmode		poll		# poll, thread
-audio_level		no
+audio_level		    no
 ausrc_format		s16		# s16, float, ..
 auplay_format		s16		# s16, float, ..
 auenc_format		s16		# s16, float, ..
@@ -49,25 +49,25 @@ audio_telev_pt		101		# payload type for telephone-event
 # Video
 #video_source		v4l2,/dev/video0
 #video_display		x11,nil
-video_size		640x480
+video_size		    640x480
 video_bitrate		1000000
-video_fps		30.00
+video_fps		    30.00
 video_fullscreen	no
 videnc_format		yuv420p
 
 # AVT - Audio/Video Transport
-rtp_tos			184
+rtp_tos			    184
 rtp_video_tos		136
-#rtp_ports		10000-20000
+#rtp_ports		    10000-20000
 #rtp_bandwidth		512-1024 # [kbit/s]
 audio_jitter_buffer_type	fixed		# off, fixed, adaptive
 audio_jitter_buffer_delay	5-10		# (min. frames)-(max. packets)
 video_jitter_buffer_type	fixed		# off, fixed, adaptive
 video_jitter_buffer_delay	5-50		# (min. frames)-(max. packets)
-rtp_stats		no
+rtp_stats		    no
 #rtp_timeout		60
-#avt_bundle		no
-#rtp_rxmode		main
+#avt_bundle		    no
+#rtp_rxmode		    main
 
 # Network
 #dns_server		1.1.1.1:53
@@ -112,15 +112,21 @@ module			auresamp.so
 #module			webrtc_aec.so
 
 # Audio driver Modules
-# FIXME: probably all but aufile.so can be disabled
-module			alsa.so
-module			pulse.so
-module			pipewire.so
+# ALSA, Pulse, Pipewire, JACK, Portaudio, etc: they all would try to connect
+# to the (etherogeneous) world of Linux audio. This addon is for HomeAssistant
+# which typically runs on HW without any type of (direct) audio player.
+# So we disable all of them.
+#module			alsa.so
+#module			pulse.so
+#module			pipewire.so
 #module			jack.so
 #module			portaudio.so
 #module			aubridge.so
-module			aufile.so
 #module			ausine.so
+
+# aufile is what allows us to load WAV files from disk
+module			aufile.so
+
 
 # Video codec Modules (in order)
 #module			avcodec.so
@@ -190,7 +196,6 @@ module_app		netroam.so
 
 # DTLS SRTP parameters
 #dtls_srtp_use_ec	prime256v1
-
 
 # UI Modules parameters
 #cons_listen		0.0.0.0:5555 # cons - Console UI UDP/TCP sockets


### PR DESCRIPTION
This PR:
* adds caching for TTS output files... so that once a notification has been sent, identical notifications won't result in traffic to the TTS service  (e.g. Google Translate) anymore
* tries to reduce errors reported by baresip due to ALSA not being avail inside docker
* fixes an issue with sync mode requests where the HTTP server was not terminating properly the HTTP transaction; now it does terminate that correctly, provides every 5sec some chunked update to the client and uses Trailer headers